### PR TITLE
Stop libpng colour-profile warnings from failing uploads

### DIFF
--- a/src/Images/ImageManipulator.php
+++ b/src/Images/ImageManipulator.php
@@ -188,16 +188,26 @@ class ImageManipulator
             $this->safeImagePath = tempnam('/tmp', '');
             $mimeType = $this->getMimeType();
 
+            // Diagnostics are suppressed deliberately. GD's decoders emit E_WARNING for
+            // recoverable defects it then decodes anyway — most commonly
+            // "libpng warning: iCCP: known incorrect sRGB profile", which is a cosmetic
+            // colour-profile complaint produced by plenty of ordinary editors. Laravel's
+            // HandleExceptions promotes any warning to an ErrorException, so an
+            // unsuppressed call throws straight out of getDominantColor() and fails the
+            // entire upload for an image GD was perfectly happy to read.
+            //
+            // A false return is the real failure signal, and the check below already
+            // handles it by reporting "no safe image" rather than throwing.
             $image = null;
             switch ($mimeType) {
                 case 'image/png':
-                    $image = imagecreatefrompng($this->imagePath);
+                    $image = @imagecreatefrompng($this->imagePath);
                     break;
                 case 'image/jpeg':
-                    $image = imagecreatefromjpeg($this->imagePath);
+                    $image = @imagecreatefromjpeg($this->imagePath);
                     break;
                 case 'image/gif':
-                    $image = imagecreatefromgif($this->imagePath);
+                    $image = @imagecreatefromgif($this->imagePath);
                     break;
             }
 


### PR DESCRIPTION
Fixes Sentry `BACKEND-Q` — `ErrorException: imagecreatefrompng(): gd-png: libpng warning: iCCP: known incorrect sRGB profile` on `POST /api/upload`.

## The bug

GD's decoders emit `E_WARNING` for recoverable defects they then decode anyway. The common one is `libpng warning: iCCP: known incorrect sRGB profile` — a cosmetic colour-profile complaint produced by plenty of ordinary image editors.

Laravel's `HandleExceptions` promotes any warning to an `ErrorException`, so the unsuppressed calls in `getSafeImagePath()` threw straight out of `getDominantColor()` → `UploadData::store()` and **failed the entire upload** for an image GD was perfectly happy to read.

`getSafeImagePath()` already treats a `false` return as "no safe image" and reports `null` rather than throwing — that graceful path just never got the chance to run.

## The fix

Suppress diagnostics on the three `imagecreatefrom*` calls and keep relying on the `false` return as the real failure signal. `HandleExceptions::handleError()` gates on `error_reporting() & $level`, which is exactly what `@` zeroes, so this is the mechanism that makes the existing check reachable.

## Verification

Driven through the real `ImageManipulator` under a handler replicating `HandleExceptions::handleError()` verbatim, including the `error_reporting()` gate:

| fixture | before | after |
|---|---|---|
| PNG that warns but decodes | colour `#0c7ccc`, no exception | colour `#0c7ccc`, no exception |
| genuinely undecodable PNG | **`ErrorException` at `ImageManipulator.php:194`** | `null`, no exception |

The "before" failure reproduces BACKEND-Q's exact exception class, file and line. Note the synthetic warning fixture triggers a libpng warning that goes to stderr rather than through PHP, so the specific `known incorrect sRGB profile` string is not reproduced locally — that needs a known-bad sRGB ICC profile, which libpng matches by checksum. The undecodable case does exercise the same `php_error_docref` path (`imagecreatefrompng(): gd-png:` prefix) that the production event came through.

Left alone deliberately:
- `getimagesize()` (line 29) is also unsuppressed, but suppressing it would just move the failure to `$this->dimensions[0]` on `false`. Needs a real null-handling decision and a return-type change — separate concern.
- `imagejpeg()` (line 210) failing is a genuine "cannot write temp file" error that should surface, not be swallowed.